### PR TITLE
Fix typo on registry_id action input

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Waits for ECR repository replications to be succeeded on GitHub Actions.
 ### Using Repository URI
 
 ```yaml
-- uses: siketyan/wait-for-replication-action@v1
+- uses: siketyan/wait-for-ecr-replication-action@v1
   with:
     image_tag: latest
     repository_uri: 0123456789.dkr.ecr.ap-northeast-1.amazonaws.com/my-image
@@ -17,7 +17,7 @@ Waits for ECR repository replications to be succeeded on GitHub Actions.
 ### Using Repository Name and Registry ID
 
 ```yaml
-- uses: siketyan/wait-for-replication-action@v1
+- uses: siketyan/wait-for-ecr-replication-action@v1
   with:
     image_tag: latest
     repository_name: my-image

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
   repository_name:
     required: false
     description: Name of the ECR repository. Either repository_uri or repository_name is required.
-  regisry_id:
+  registry_id:
     required: false
     description: ID of the ECR registry. Defaults to the default registry of the current account.
   region:


### PR DESCRIPTION
Although the action is working as it should with the typo present, this should silence the warning present when supplying the `registry_id` parameter.

> Warning: Unexpected input(s) 'registry_id', valid inputs are ['token', 'interval', 'image_digest', 'image_tag', 'repository_uri', 'repository_name', 'regisry_id', 'region']

I also took this opportunity to fix the action name in the README.md file.